### PR TITLE
feat: initial values and reset option

### DIFF
--- a/easy_form/example/lib/examples/live_update.dart
+++ b/easy_form/example/lib/examples/live_update.dart
@@ -39,7 +39,11 @@ class LiveUpdateFormContent extends StatelessWidget {
           builder: (context, snapshot) {
             return Text(snapshot?.data?.toString() ?? "No interactions yet");
           },
-        )
+        ),
+        RaisedButton(
+          onPressed: context.easyForm.resetForm,
+          child: Text("Reset form"),
+        ),
       ],
     );
   }

--- a/easy_form/example/lib/examples/with_initial_values.dart
+++ b/easy_form/example/lib/examples/with_initial_values.dart
@@ -1,0 +1,40 @@
+import 'package:easy_form/easy_form.dart';
+import 'package:flutter/material.dart';
+
+class WithInitialValues extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return EasyForm(
+      initialValues: {
+        "name": "Initial Name"
+      },
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text("With initial values and reset button"),
+        ),
+        body: WithInitialValuesFormContent(),
+      ),
+    );
+  }
+}
+
+class WithInitialValuesFormContent extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      padding: EdgeInsets.all(10),
+      children: <Widget>[
+        EasyTextField(
+          attribute: 'name',
+          textField: TextField(
+            decoration: InputDecoration(hintText: "Your name"),
+          ),
+        ),
+        RaisedButton(
+          onPressed: context.easyForm.resetForm,
+          child: Text("Reset form"),
+        ),
+      ],
+    );
+  }
+}

--- a/easy_form/example/lib/main.dart
+++ b/easy_form/example/lib/main.dart
@@ -3,15 +3,18 @@ import 'package:example/examples/simple_form.dart';
 import 'package:example/examples/dynamic_control.dart';
 import 'package:flutter/material.dart';
 
+import 'examples/with_initial_values.dart';
+
 void main() {
   runApp(MyApp());
 }
 
 final _routes = {
-  "/": (BuildContext context) => Examples(),
-  "Simple Form": (BuildContext context) => SimpleForm(),
-  "Live Update": (BuildContext context) => LiveUpdate(),
-  "Dynamic field value control": (BuildContext context) => DynamicControl(),
+  "/": (BuildContext _) => Examples(),
+  "Simple Form": (BuildContext _) => SimpleForm(),
+  "Live Update": (BuildContext _) => LiveUpdate(),
+  "Dynamic field value control": (BuildContext _) => DynamicControl(),
+  "Initial values and reset button": (BuildContext _) => WithInitialValues(),
 };
 
 class MyApp extends StatelessWidget {

--- a/easy_form/lib/src/easy_form.dart
+++ b/easy_form/lib/src/easy_form.dart
@@ -6,8 +6,15 @@ import 'easy_form_field.dart';
 
 class EasyForm extends StatefulWidget {
   final Widget child;
+  final Map<String, dynamic> initialValues;
 
-  const EasyForm({Key key, this.child}) : super(key: key);
+  const EasyForm({
+    Key key,
+    @required this.child,
+    this.initialValues = const {},
+  })  : assert(initialValues != null),
+        assert(child != null),
+        super(key: key);
 
   @override
   EasyFormState createState() => EasyFormState();
@@ -51,13 +58,25 @@ class EasyFormState extends State<EasyForm> {
     _changesCtrl.sink.add(values);
   }
 
+  void resetForm() {
+    _fields.forEach((key, _) {
+      setFieldValue(key, initialValueFor(key));
+    });
+  }
+
+  T initialValueFor<T>(String attributeName) {
+    return widget.initialValues[attributeName];
+  }
+
   T getFieldValue<T>(String attributeName) {
-    return _fields[attributeName].value;
+    assert(_fields.containsKey(attributeName), "The $attributeName field is not registered");
+
+    return _fields[attributeName].value ?? initialValueFor(attributeName);
   }
 
   Map<String, dynamic> get values {
     return _fields.map((key, field) {
-      return MapEntry(key, field.value);
+      return MapEntry(key, field.value ?? widget.initialValues[key]);
     });
   }
 }

--- a/easy_form/lib/src/easy_form_field.dart
+++ b/easy_form/lib/src/easy_form_field.dart
@@ -22,4 +22,6 @@ abstract class EasyFormField<T> {
   void notifyChange() {
     easyForm.notifyChange();
   }
+
+  T get initialValue => easyForm.initialValueFor(this.attributeName);
 }

--- a/easy_form/lib/src/fields/text_field.dart
+++ b/easy_form/lib/src/fields/text_field.dart
@@ -42,6 +42,8 @@ class _EasyTextFieldState extends State<EasyTextField>
   }
 
   void _configureRenderElement() {
+    textController.text = initialValue ?? "";
+
     _renderElement = TextFieldFactory.copyFromWith(
       widget.textField,
       controller: textController,
@@ -66,7 +68,7 @@ class _EasyTextFieldState extends State<EasyTextField>
   @override
   set value(String value) {
     setState(() {
-      textController.text = value;
+      textController.text = value ?? "";
     });
   }
 


### PR DESCRIPTION
# Feat: Initial values and reset form
Allows init the form with predefined values and reset anytime

## Usage
### Initial values
You gonna need to pass a map where each key should match the field attribute name

```dart
EasyForm(
  initialValues: {
    "name": "Initial Name"
  },
  child: YourForm()
);
```

### Reseting the form
```dart
RaisedButton(
  onPressed: context.easyForm.resetForm,
  child: Text("Reset form"),
),
```

## Preview
| No initial value | With initial values |
|--|--|
| ![no_initial](https://user-images.githubusercontent.com/10780132/85231404-feef0900-b3cc-11ea-9451-35da7375c1aa.gif) | ![with_initial](https://user-images.githubusercontent.com/10780132/85231407-13330600-b3cd-11ea-9e4c-73d05e6ed14f.gif) |

