### PR TITLE
Fix string field logic

### DIFF
--- a/easy_form/lib/src/easy_form_field_state.dart
+++ b/easy_form/lib/src/easy_form_field_state.dart
@@ -28,7 +28,7 @@ class EasyFormFieldState<T> with ChangeNotifier {
   String? get error => _error;
   bool get hasError => error != null;
 
-  bool get _isStringField => initialValue is String || initialValue is String?;
+  bool get _isStringField => initialValue is String;
 
   set value(T newValue) {
     _value = newValue;


### PR DESCRIPTION
# Changes

- The bug was that if we set initialValues to null, the library would treat that value as a String field.

